### PR TITLE
Upgrade solana test validator to 2.0.14

### DIFF
--- a/src/integration-test/resources/Dockerfile
+++ b/src/integration-test/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/solana:v1.18.25
+FROM anzaxyz/agave:v2.0.14
 
 USER root
 

--- a/src/integration-test/resources/solana-run.sh
+++ b/src/integration-test/resources/solana-run.sh
@@ -23,9 +23,11 @@ fi
 PATH=$PWD/target/$profile:$PATH
 
 ok=true
-for program in solana-{faucet,genesis,keygen,validator}; do
+for program in solana-{faucet,genesis,keygen,test-validator}; do
   $program -V || ok=false
 done
+agave-validator -V || ok=false
+
 $ok || {
   echo
   echo "Unable to locate required programs.  Try building them first with:"
@@ -35,7 +37,7 @@ $ok || {
   exit 1
 }
 
-export RUST_LOG=${RUST_LOG:-solana=info,solana_runtime::message_processor=debug} # if RUST_LOG is unset, default to info
+export RUST_LOG=${RUST_LOG:-solana=info,agave=info,solana_runtime::message_processor=debug} # if RUST_LOG is unset, default to info
 export RUST_BACKTRACE=1
 dataDir=$PWD/config/"$(basename "$0" .sh)"
 ledgerDir=$PWD/config/ledger
@@ -99,7 +101,7 @@ solana-test-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &
 validator=$!
 
 
-solana config set --url "http://localhost:8899"
+solana config set --url localhost
 
 set +e
 while true; do

--- a/src/test-support/java/com/lmax/solana4j/SolanaDriver.java
+++ b/src/test-support/java/com/lmax/solana4j/SolanaDriver.java
@@ -60,7 +60,7 @@ public class SolanaDriver
                                            final TestKeyPair payer,
                                            final Slot slot)
     {
-        final Blockhash recentBlockhash = solanaApi.getRecentBlockHash();
+        final Blockhash recentBlockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().createAddressLookupTable(
                 programDerivedAddress,
@@ -79,7 +79,7 @@ public class SolanaDriver
                                            final List<TestPublicKey> addressesToAdd,
                                            final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash recentBlockhash = solanaApi.getRecentBlockHash();
+        final Blockhash recentBlockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().extendAddressLookupTable(
                 addressLookupTable.getSolana4jPublicKey(),
@@ -103,7 +103,7 @@ public class SolanaDriver
             final int accountSpan,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash recentBlockhash = solanaApi.getRecentBlockHash();
+        final Blockhash recentBlockhash = solanaApi.getLatestBlockhash();
         final long rentExemption = solanaApi.getMinimalBalanceForRentExemption(accountSpan);
 
         final String transactionBlob = getTransactionFactory().createMintAccount(
@@ -132,7 +132,7 @@ public class SolanaDriver
             final TestKeyPair payer,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash recentBlockhash = solanaApi.getRecentBlockHash();
+        final Blockhash recentBlockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().mintTo(
                 tokenProgram,
@@ -158,7 +158,7 @@ public class SolanaDriver
             final List<AddressLookupTable> addressLookupTables)
     {
         final Long rentExemption = solanaApi.getMinimalBalanceForRentExemption(accountSpan);
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().createTokenAccount(
                 tokenProgram,
@@ -193,7 +193,7 @@ public class SolanaDriver
             final List<AddressLookupTable> addressLookupTables)
     {
         final Long rentExemption = solanaApi.getMinimalBalanceForRentExemption(accountSpan);
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().createNonce(
                 nonceAccount.getSolana4jPublicKey(),
@@ -218,7 +218,7 @@ public class SolanaDriver
             final List<AddressLookupTable> addressLookupTables)
     {
         final Long rentExemption = solanaApi.getMinimalBalanceForRentExemption(accountSpan);
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().createMultiSigAccount(
                 tokenProgram,
@@ -241,7 +241,7 @@ public class SolanaDriver
             final TestKeyPair payer,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().advanceNonce(
                 account.getSolana4jPublicKey(),
@@ -264,7 +264,7 @@ public class SolanaDriver
             final List<TestKeyPair> signers,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().tokenTransfer(
                 tokenProgram,
@@ -287,7 +287,7 @@ public class SolanaDriver
             final TestKeyPair payer,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().solTransfer(
                 from.getSolana4jPublicKey(),
@@ -310,7 +310,7 @@ public class SolanaDriver
             final TestKeyPair payer,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().createAssociatedTokenAccount(
                 tokenProgram,
@@ -336,7 +336,7 @@ public class SolanaDriver
             final List<TestKeyPair> signers,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().setTokenAccountAuthority(
                 tokenProgram,
@@ -354,7 +354,7 @@ public class SolanaDriver
 
     public String setComputeUnits(final int computeUnitLimit, final long computeUnitPrice, final TestKeyPair payer)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().setComputeUnits(
                 computeUnitLimit,
@@ -374,7 +374,7 @@ public class SolanaDriver
             final List<TestKeyPair> signers,
             final List<AddressLookupTable> addressLookupTables)
     {
-        final Blockhash blockhash = solanaApi.getRecentBlockHash();
+        final Blockhash blockhash = solanaApi.getLatestBlockhash();
 
         final String transactionBlob = getTransactionFactory().setBpfUpgradeableProgramUpgradeAuthority(
                 program,

--- a/src/test-support/java/com/lmax/solana4j/solanaclient/api/SolanaApi.java
+++ b/src/test-support/java/com/lmax/solana4j/solanaclient/api/SolanaApi.java
@@ -18,7 +18,7 @@ public interface SolanaApi
 
     Long getSlot();
 
-    Blockhash getRecentBlockHash();
+    Blockhash getLatestBlockhash();
 
     Long getMinimalBalanceForRentExemption(int size);
 }

--- a/src/test-support/java/com/lmax/solana4j/solanaclient/jsonrpc/SolanaClient.java
+++ b/src/test-support/java/com/lmax/solana4j/solanaclient/jsonrpc/SolanaClient.java
@@ -124,11 +124,11 @@ public class SolanaClient implements SolanaApi
     }
 
     @Override
-    public Blockhash getRecentBlockHash()
+    public Blockhash getLatestBlockhash()
     {
         return rpcClient.queryForObject(new TypeReference<RpcWrapperDTO<BlockhashDTO>>()
         {
-        }, "getRecentBlockhash").getValue();
+        }, "getLatestBlockhash").getValue();
     }
 
     @Override


### PR DESCRIPTION
Solana have now recommended 2.0.14 for mainnet-beta. Additionally, anzaxyz/agave is the official Solana validator image.

As part of this, rpc method `getRecentBlockhash` was removed and suggests to use `getLastestBlockhash` instead.
https://solana.com/docs/rpc/deprecated/getrecentblockhash