### PR TITLE
Handle the case where there is no parsed instruction

### DIFF
--- a/client/src/main/java/com/lmax/solana4j/client/jsonrpc/TransactionResponseDTO.java
+++ b/client/src/main/java/com/lmax/solana4j/client/jsonrpc/TransactionResponseDTO.java
@@ -752,7 +752,7 @@ final class TransactionResponseDTO implements TransactionResponse
             @Override
             public Map<String, Object> getInstructionParsed()
             {
-                return instructionParsed.get();
+                return instructionParsed != null ? instructionParsed.get() : null;
             }
 
             @Override

--- a/client/src/test/java/com/lmax/solana4j/client/jsonrpc/GetJsonParsedTransactionTest.java
+++ b/client/src/test/java/com/lmax/solana4j/client/jsonrpc/GetJsonParsedTransactionTest.java
@@ -77,4 +77,24 @@ public class GetJsonParsedTransactionTest
         assertThat(instructionParsed).isEqualTo(parsed);
     }
 
+    @Test
+    public void shouldHandleNoInstructionParsed() throws IOException
+    {
+        final ObjectReader objectReader = mapper.readerFor(new TypeReference<RpcWrapperDTO<TransactionResponseDTO>>()
+        {
+        });
+        final RpcWrapperDTO<TransactionResponseDTO> response = objectReader.readValue(GetJsonParsedTransactionTest.class.getResource("/transactionWithNoParsedInstruction.json"));
+
+        final Map<String, Object> instructionParsed =
+                response
+                        .getResult()
+                        .getTransactionData()
+                        .getParsedTransactionData()
+                        .getMessage()
+                        .getInstructions()
+                        .get(0)
+                        .getInstructionParsed();
+
+        assertThat(instructionParsed).isNull();
+    }
 }

--- a/client/src/test/resources/transactionWithNoParsedInstruction.json
+++ b/client/src/test/resources/transactionWithNoParsedInstruction.json
@@ -1,0 +1,69 @@
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "blockTime": 1751909390,
+    "meta": {
+      "computeUnitsConsumed": 150,
+      "err": null,
+      "fee": 5000,
+      "innerInstructions": [],
+      "logMessages": [
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success"
+      ],
+      "postBalances": [
+        999998998990000,
+        1000990000,
+        1
+      ],
+      "postTokenBalances": [],
+      "preBalances": [
+        999999998995000,
+        990000,
+        1
+      ],
+      "preTokenBalances": [],
+      "rewards": [],
+      "status": {
+        "Ok": null
+      }
+    },
+    "slot": 425,
+    "transaction": {
+      "message": {
+        "accountKeys": [
+          {
+            "pubkey": "osRAr6v5ujNNmDupwmcdFNV2ob2KB6AVVPidyw49Y9s",
+            "signer": true,
+            "source": "transaction",
+            "writable": true
+          },
+          {
+            "pubkey": "sCR7NonpU3TrqvusEiA4MAwDMLfiY1gyVPqw2b36d8V",
+            "signer": false,
+            "source": "transaction",
+            "writable": true
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "signer": false,
+            "source": "transaction",
+            "writable": false
+          }
+        ],
+        "instructions": [
+          {
+            "program": "system",
+            "programId": "11111111111111111111111111111111",
+            "stackHeight": null
+          }
+        ],
+        "recentBlockhash": "8kEyLU25YjsJFV4EtZAZmVwc7rSGF65j84z48We6cRKw"
+      },
+      "signatures": [
+        "iNbt8SC8TgiZCekuF8Qz7cUZ2qykVmKmbFwPTQZDZ2XVGZvWWRWRcybyRMAfsLd8a7Gzh6bHjFAhSJTz1iXdoT5"
+      ]
+    }
+  },
+  "id": 14
+}


### PR DESCRIPTION
If the request doesn't specify an encoding of jsonParsed then the parsed field will be absent, so we need to handle that.